### PR TITLE
fix: uncomment sync-branch setting in beads config.yaml

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -42,7 +42,7 @@
 # This setting persists across clones (unlike database config which is gitignored).
 # Can also use BEADS_SYNC_BRANCH env var for local override.
 # If not set, bd sync will require you to run 'bd config set sync.branch <branch>'.
-# sync-branch: "beads-sync"
+sync-branch: "beads-sync"
 
 # Multi-repo configuration (experimental - bd-307)
 # Allows hydrating from multiple repositories and routing writes to the correct JSONL


### PR DESCRIPTION
Hey mate,

i think its a good idea to uncomment the sync-branch setting for beads. Otherwise the repos commit history will always look like in the screenshot below :)

<img width="1301" height="573" alt="image" src="https://github.com/user-attachments/assets/42d5d1fc-a8ed-4a57-9100-4b1f174bc9be" />
