### PR TITLE
feat: Add copy-from-current toggle to TUI profile creation

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -930,11 +930,8 @@ fn render_input_popup(frame: &mut Frame, app: &App) {
     render_create_profile_input_field(frame, app, chunks[0]);
     render_create_profile_checkbox(frame, app, chunks[1]);
 
-    render_create_profile_input_field(frame, app, chunks[0]);
-    render_create_profile_checkbox(frame, app, chunks[1]);
-
     let tips_idx = if app.create_profile_error.is_some() {
-        render_create_profile_error(frame, &app.create_profile_error.as_ref().unwrap(), chunks[3]);
+        render_create_profile_error(frame, app.create_profile_error.as_ref().unwrap(), chunks[3]);
         5
     } else {
         3


### PR DESCRIPTION
G'day! 👋

This PR adds a handy checkbox to the TUI when creating new profiles, letting users choose whether to copy their current config or start fresh. Previously this was only available via the CLI commands, but now it's all there in the TUI for those who prefer a bit of point-and-click action.

### What Changed

Added a toggle to the profile creation dialog in the TUI that lets users decide whether to copy their current harness configuration or create a completely empty profile. The implementation includes:

- New state fields `create_profile_copy_current` and `create_profile_focused_on_checkbox` in the App struct
- Tab key cycles focus between the profile name input and the checkbox
- Space key toggles the checkbox when it's focused
- Visual feedback showing which element has focus (yellow styling and bold text for the active element)
- Conditionally calls either `create_from_current_with_resources()` or `create_profile()` based on the toggle
- Refactored the profile creation state management into `start_create_profile()` and `exit_create_profile()` helper methods for cleaner code
- Fixed input popup rendering to be properly layered and widened it slightly to accommodate the new UI

The UI shows a clean checkbox with text that updates based on state:
- `[x] Copy from current config` (when enabled)
<img width="503" height="211" alt="image" src="https://github.com/user-attachments/assets/1724b97a-fbdf-4922-a97d-09c41c2e5c38" />

- `[ ] Copy from current config` (when disabled)
<img width="505" height="206" alt="image" src="https://github.com/user-attachments/assets/ed9cfd76-07d6-41b6-b5b4-87ab5f34b228" />

### CLI Parity

This brings the TUI inline with the CLI, which already supported both creation modes:
- `bridle profile create <harness> <name>` → creates an empty profile
- `bridle profile create <harness> <name> --from-current` → copies from current config

Now users can do the same thing directly in the TUI.

### Backwards Compatibility

To keep things steady and not break existing workflows, the default is `true` (copy from current) — same behaviour as before, just with a new option to opt out when you want a completely fresh profile.