### PR TITLE
fix(perf): resolve TUI and profile switching performance issues

### DIFF
--- a/src/config/manager/lifecycle.rs
+++ b/src/config/manager/lifecycle.rs
@@ -40,6 +40,9 @@ impl ProfileManager {
         std::fs::create_dir_all(&backup_path)?;
         files::copy_config_files(harness, true, &backup_path)?;
 
+        let extra_dir = self.backups_dir().join(harness.id()).join("extra");
+        let _ = files::backup_session_data(&source_dir, &extra_dir);
+
         Ok(backup_path)
     }
 


### PR DESCRIPTION
## Summary

Fixes critical performance regression introduced in v0.2.4:
- TUI harness switching went from instant to ~4 seconds
- Profile switching took ~6 seconds for Claude Code

## Root Causes & Fixes

### 1. TUI Harness Switching (h/l keys)
**Problem:** `sync_active_profiles()` was called on every `refresh_profiles()`, copying all active profile directories on each keystroke.

**Fix:** Removed sync from refresh. Now syncs only on:
- Explicit refresh (`r` key)
- Exit (`q`/`Esc`/`Ctrl+C`)

### 2. Profile Switching
**Problem:** Session data (transcripts, debug, etc.) was being copied with profiles. Claude Code had 300MB+ of transcripts.

**Fix:** 
- Added `EXCLUDED_ENTRIES` for session data
- Session data now persists in place across profile switches
- Only configuration files are swapped

### 3. Session Data Loss
**Problem:** `switch_config_dir_safely()` was wiping ALL files including session data.

**Fix:** Modified wipe step to preserve session data directories.

### 4. Backup Bloat
**Problem:** Backups grew to 3GB+ with duplicated transcripts.

**Fix:**
- Added `backup_session_data()` function with separate `extra/` folder
- Auto-rotates to keep max 5 session backups
- Only runs on explicit backup commands

## Excluded Session Data (persists across profiles)
- `transcripts`, `debug`, `statsig`, `projects`, `todos`
- `shell-snapshots`, `history.jsonl`, `node_modules`

## Performance Impact

| Operation | Before | After |
|-----------|--------|-------|
| TUI harness switch | ~4s | instant |
| Claude profile switch | ~6s | <1s |
| Backup size (Claude) | 3.1GB | ~5MB |

## Testing
- All 128 tests pass
- Manual testing confirmed instant harness switching
- Profile switches now complete in <1 second