### PR TITLE
fix(ci): update release workflow for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@
 name: Release
 permissions:
   "contents": "write"
+  "id-token": "write"
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -342,15 +343,14 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
             npm publish --access public "./npm/${pkg}"
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
 
   announce:
     needs:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -5,6 +5,7 @@ members = ["cargo:."]
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.30.3"
+allow-dirty = ["ci"]
 # CI backends to support
 ci = "github"
 # The installers to generate for each app


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission for npm provenance attestation
- Update Node.js version from 20.x to 24
- Remove `NODE_AUTH_TOKEN` env (using provenance-based auth instead)
- Add `allow-dirty = ["ci"]` to dist-workspace.toml